### PR TITLE
Migrate packets to immutable/null safe objects

### DIFF
--- a/common/src/main/kotlin/org/sandboxpowered/silica/content/block/BlockEntityProvider.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/content/block/BlockEntityProvider.kt
@@ -1,7 +1,10 @@
 package org.sandboxpowered.silica.content.block
 
 import com.artemis.ArchetypeBuilder
+import com.artemis.systems.IteratingSystem
 
-interface BlockEntityProvider {
+interface BlockEntityProvider : Block {
     fun createArchetype(): ArchetypeBuilder
+
+    fun createProcessingSystem(): IteratingSystem
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/content/block/FurnaceBlock.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/content/block/FurnaceBlock.kt
@@ -1,13 +1,15 @@
 package org.sandboxpowered.silica.content.block
 
 import com.artemis.ArchetypeBuilder
+import com.artemis.systems.IteratingSystem
 import org.sandboxpowered.silica.content.block.BlockProperties.HORIZONTAL_FACING
 import org.sandboxpowered.silica.content.block.BlockProperties.LIT
 import org.sandboxpowered.silica.ecs.component.FurnaceLogicComponent
-import org.sandboxpowered.silica.world.state.StateProvider
-import org.sandboxpowered.silica.world.state.block.BlockState
+import org.sandboxpowered.silica.ecs.system.FurnaceProcessingSystem
 import org.sandboxpowered.silica.util.Identifier
 import org.sandboxpowered.silica.util.extensions.add
+import org.sandboxpowered.silica.world.state.StateProvider
+import org.sandboxpowered.silica.world.state.block.BlockState
 
 class FurnaceBlock(identifier: Identifier) : BaseBlock(identifier), BlockEntityProvider {
     override fun appendProperties(builder: StateProvider.Builder<Block, BlockState>) {
@@ -15,11 +17,7 @@ class FurnaceBlock(identifier: Identifier) : BaseBlock(identifier), BlockEntityP
         builder.add(HORIZONTAL_FACING, LIT)
     }
 
-    override fun createArchetype(): ArchetypeBuilder {
-        val builder = ArchetypeBuilder()
+    override fun createArchetype(): ArchetypeBuilder = ArchetypeBuilder().apply { add<FurnaceLogicComponent>() }
 
-        builder.add<FurnaceLogicComponent>()
-
-        return builder
-    }
+    override fun createProcessingSystem(): IteratingSystem = FurnaceProcessingSystem()
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/registry/SilicaRegistries.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/registry/SilicaRegistries.kt
@@ -1,13 +1,21 @@
 package org.sandboxpowered.silica.registry
 
 import org.sandboxpowered.silica.content.block.Block
+import org.sandboxpowered.silica.content.block.BlockEntityProvider
 import org.sandboxpowered.silica.content.fluid.Fluid
 import org.sandboxpowered.silica.content.item.Item
 import org.sandboxpowered.silica.util.Identifier.Companion.of as id
 
 object SilicaRegistries {
     @JvmField
-    val BLOCK_REGISTRY = SilicaRegistry(id("minecraft", "block"), Block::class.java)
+    val BLOCK_REGISTRY = SilicaRegistry(id("minecraft", "block"), Block::class.java).apply {
+        addListener {
+            if (it is BlockEntityProvider)
+                BLOCKS_WITH_BE.add(it)
+        }
+    }
+
+    val BLOCKS_WITH_BE = ArrayList<BlockEntityProvider>()
 
     @JvmField
     val ITEM_REGISTRY = SilicaRegistry(id("minecraft", "item"), Item::class.java)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/registry/SilicaRegistry.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/registry/SilicaRegistry.kt
@@ -8,13 +8,19 @@ import java.util.stream.Stream
 class SilicaRegistry<T : RegistryEntry<T>>(private val id: Identifier, override val type: Class<T>) : Registry<T> {
     var internalMap: MutableMap<Identifier, T> = HashMap()
     var registryEntries: MutableMap<Identifier, SilicaRegistryEntry<T>> = HashMap()
+    var listeners: MutableList<(T) -> Unit> = ArrayList()
 
     fun <X : RegistryEntry<X>> cast(): Registry<X> {
         return this as Registry<X>
     }
 
+    fun addListener(listener: (T) -> Unit) {
+        listeners.add(listener)
+    }
+
     fun register(t: T): T {
         internalMap[t.identifier] = t
+        listeners.forEach { it(t) }
         return t
     }
 

--- a/common/src/main/kotlin/org/sandboxpowered/silica/util/Util.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/util/Util.kt
@@ -32,11 +32,9 @@ object Util {
         }
     }
 
-    inline fun <reified T> getLogger(): Logger {
-        return LogManager.getLogger(T::class.java)
-    }
+    inline fun <reified T> getLogger(): Logger = LogManager.getLogger(T::class.java)
 
-    private val ktorClient = HttpClient() {
+    private val ktorClient = HttpClient {
         install(JsonFeature) {
             serializer = GsonSerializer()
         }
@@ -66,17 +64,15 @@ object Util {
         return file
     }
 
-    private fun findMinecraft(version: String): File? {
-        return when {
-            SystemUtils.IS_OS_WINDOWS || SystemUtils.IS_OS_LINUX -> {
-                val homeDir = when {
-                    SystemUtils.IS_OS_LINUX -> System.getenv("HOME")
-                    else -> System.getenv("APPDATA")
-                }
-                val asPath = Paths.get(homeDir, ".minecraft", "versions", version, "$version.jar")
-                if (Files.exists(asPath)) asPath.toFile() else null
+    private fun findMinecraft(version: String): File? = when {
+        SystemUtils.IS_OS_WINDOWS || SystemUtils.IS_OS_LINUX -> {
+            val homeDir = when {
+                SystemUtils.IS_OS_LINUX -> System.getenv("HOME")
+                else -> System.getenv("APPDATA")
             }
-            else -> null
+            val asPath = Paths.get(homeDir, ".minecraft", "versions", version, "$version.jar")
+            if (Files.exists(asPath)) asPath.toFile() else null
         }
+        else -> null
     }
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/util/extensions/artemisExt.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/util/extensions/artemisExt.kt
@@ -25,4 +25,8 @@ inline fun <reified T : Component> ArchetypeBuilder.add() {
     add(T::class.java)
 }
 
+inline fun <reified T : Component> ArchetypeBuilder.remove() {
+    remove(T::class.java)
+}
+
 inline fun <reified T : BaseSystem> World.getSystem(): T = getSystem(T::class.java)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/Connection.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/Connection.kt
@@ -4,10 +4,10 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.Scheduler
 import akka.actor.typed.javadsl.AskPattern
 import com.mojang.authlib.GameProfile
-import org.sandboxpowered.silica.vanilla.network.login.clientbound.LoginSuccess
-import org.sandboxpowered.silica.vanilla.network.login.serverbound.EncryptionResponse
 import org.sandboxpowered.silica.server.Network.CreateConnection
 import org.sandboxpowered.silica.server.SilicaServer
+import org.sandboxpowered.silica.vanilla.network.login.clientbound.LoginSuccess
+import org.sandboxpowered.silica.vanilla.network.login.serverbound.EncryptionResponse
 import java.time.Duration
 import java.util.*
 import javax.crypto.SecretKey

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketBase.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketBase.kt
@@ -1,6 +1,6 @@
 package org.sandboxpowered.silica.vanilla.network
 
 interface PacketBase {
-    fun read(buf: PacketByteBuf)
+    fun read(buf: PacketByteBuf) {}
     fun write(buf: PacketByteBuf)
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketBase.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketBase.kt
@@ -1,6 +1,7 @@
 package org.sandboxpowered.silica.vanilla.network
 
 interface PacketBase {
-    fun read(buf: PacketByteBuf) {}
+    @Deprecated("use PacketByteBuf constructor instead", ReplaceWith("Unit"))
+    fun read(buf: PacketByteBuf) = Unit
     fun write(buf: PacketByteBuf)
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketBase.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketBase.kt
@@ -1,7 +1,7 @@
 package org.sandboxpowered.silica.vanilla.network
 
 interface PacketBase {
-    @Deprecated("use PacketByteBuf constructor instead", ReplaceWith("Unit"))
-    fun read(buf: PacketByteBuf) = Unit
+    @Deprecated("use PacketByteBuf constructor instead")
+    fun read(buf: PacketByteBuf) {}
     fun write(buf: PacketByteBuf)
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketByteBuf.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketByteBuf.kt
@@ -7,7 +7,6 @@ import io.netty.buffer.ByteBufOutputStream
 import io.netty.handler.codec.DecoderException
 import io.netty.handler.codec.EncoderException
 import io.netty.util.ByteProcessor
-import org.sandboxpowered.silica.content.item.ItemStack
 import org.sandboxpowered.silica.nbt.NBTCompound
 import org.sandboxpowered.silica.nbt.readNbt
 import org.sandboxpowered.silica.nbt.write

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketDecoder.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/PacketDecoder.kt
@@ -10,9 +10,8 @@ class PacketDecoder(private val networkFlow: NetworkFlow) : ByteToMessageDecoder
             val buf = PacketByteBuf(inBuf)
             val packetId = buf.readVarInt()
             val protocol = ctx.channel().attr(Protocol.PROTOCOL_ATTRIBUTE_KEY).get()
-            val packet = protocol.createPacket(networkFlow, packetId)
+            val packet = protocol.createPacket(networkFlow, packetId, buf)
             if (packet != null) {
-                packet.read(buf)
                 out.add(packet)
             } else {
                 error("Unknown packet 0x${"%02x".format(packetId)}")

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/Protocol.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/Protocol.kt
@@ -24,6 +24,7 @@ import java.util.function.Function
 import java.util.function.Supplier
 import kotlin.collections.set
 
+@Suppress("unused")
 enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
     HANDSHAKE(-1, {
         server {
@@ -32,22 +33,22 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
     }),
     PLAY(0, {
         server {
-            0x00 packetDeprecated ::TeleportConfirmation
-            0x05 packetDeprecated ::ClientSettings
-            0x0A packetDeprecated ::ClientPluginChannel
-            0x0F packetDeprecated ::KeepAliveServer
-            0x11 packetDeprecated ::PlayerPosition
-            0x12 packetDeprecated ::PlayerPositionAndRotation
-            0x13 packetDeprecated ::PlayerRotation
-            0x14 packetDeprecated ::PlayerMovement
-            0x1A packetDeprecated ::PlayerDigging
+            0x00 packet ::TeleportConfirmation
+            0x05 packet ::ClientSettings
+            0x0A packet ::ClientPluginChannel
+            0x0F packet ::KeepAliveServer
+            0x11 packet ::PlayerPosition
+            0x12 packet ::PlayerPositionAndRotation
+            0x13 packet ::PlayerRotation
+            0x14 packet ::PlayerMovement
+            0x1A packet ::PlayerDigging
             0x2C packetDeprecated ::HandSwingAnimation
             0x1B packetDeprecated ::EntityAction
             0x2E packetDeprecated ::PlayerBlockPlacement
             0x25 packetDeprecated ::HeldItemChangeServerbound
         }
         client {
-            0x26 packetDeprecated ::JoinGame
+            0x26 packet ::JoinGame
             0x48 packet ::HeldItemChangeClientbound
             0x65 packetDeprecated ::DeclareRecipes
             0X66 packetDeprecated ::DeclareTags
@@ -60,14 +61,14 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
             0x22 packetDeprecated ::ChunkData
             0x25 packetDeprecated ::UpdateLight
             0x20 packetDeprecated ::WorldBorder
-            0x21 packetDeprecated ::KeepAliveClient
-            0x08 packetDeprecated ::AcknowledgePlayerDigging
-            0x0C packetDeprecated ::BlockChange
+            0x21 packet ::KeepAliveClient
+            0x08 packet ::AcknowledgePlayerDigging
+            0x0C packet ::BlockChange
             0x04 packetDeprecated ::SpawnPlayer
             0x29 packetDeprecated ::UpdateEntityPosition
             0x2A packetDeprecated ::UpdateEntityPositionRotation
             0x2B packetDeprecated ::UpdateEntityRotation
-            0x14 packetDeprecated ::InitWindowItems
+            0x14 packet ::InitWindowItems
         }
     }),
     STATUS(1, {
@@ -173,5 +174,3 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
         inline fun server(block: FlowBuilder.() -> Unit): FlowBuilder = server.apply(block)
     }
 }
-
-typealias PacketFactory = (PacketByteBuf) -> PacketBase

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/Protocol.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/Protocol.kt
@@ -20,6 +20,7 @@ import org.sandboxpowered.silica.vanilla.network.login.serverbound.HandshakeRequ
 import org.sandboxpowered.silica.vanilla.network.login.serverbound.LoginStart
 import org.sandboxpowered.silica.vanilla.network.play.clientbound.*
 import org.sandboxpowered.silica.vanilla.network.play.serverbound.*
+import java.util.function.Function
 import java.util.function.Supplier
 import kotlin.collections.set
 
@@ -31,42 +32,42 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
     }),
     PLAY(0, {
         server {
-            0x00 packet ::TeleportConfirmation
-            0x05 packet ::ClientSettings
-            0x0A packet ::ClientPluginChannel
-            0x0F packet ::KeepAliveServer
-            0x11 packet ::PlayerPosition
-            0x12 packet ::PlayerPositionAndRotation
-            0x13 packet ::PlayerRotation
-            0x14 packet ::PlayerMovement
-            0x1A packet ::PlayerDigging
-            0x2C packet ::HandSwingAnimation
-            0x1B packet ::EntityAction
-            0x2E packet ::PlayerBlockPlacement
-            0x25 packet ::HeldItemChangeServerbound
+            0x00 packetDeprecated ::TeleportConfirmation
+            0x05 packetDeprecated ::ClientSettings
+            0x0A packetDeprecated ::ClientPluginChannel
+            0x0F packetDeprecated ::KeepAliveServer
+            0x11 packetDeprecated ::PlayerPosition
+            0x12 packetDeprecated ::PlayerPositionAndRotation
+            0x13 packetDeprecated ::PlayerRotation
+            0x14 packetDeprecated ::PlayerMovement
+            0x1A packetDeprecated ::PlayerDigging
+            0x2C packetDeprecated ::HandSwingAnimation
+            0x1B packetDeprecated ::EntityAction
+            0x2E packetDeprecated ::PlayerBlockPlacement
+            0x25 packetDeprecated ::HeldItemChangeServerbound
         }
         client {
-            0x26 packet ::JoinGame
+            0x26 packetDeprecated ::JoinGame
             0x48 packet ::HeldItemChangeClientbound
-            0x65 packet ::DeclareRecipes
-            0X66 packet ::DeclareTags
-            0x1B packet ::EntityStatus
-            0x12 packet ::DeclareCommands
-            0x38 packet ::SetPlayerPositionAndLook
-            0x39 packet ::UnlockRecipes
-            0x36 packet ::PlayerInfo
-            0x49 packet ::UpdateChunkPosition
-            0x22 packet ::ChunkData
-            0x25 packet ::UpdateLight
-            0x20 packet ::WorldBorder
-            0x21 packet ::KeepAliveClient
-            0x08 packet ::AcknowledgePlayerDigging
-            0x0C packet ::BlockChange
-            0x04 packet ::SpawnPlayer
-            0x29 packet ::UpdateEntityPosition
-            0x2A packet ::UpdateEntityPositionRotation
-            0x2B packet ::UpdateEntityRotation
-            0x14 packet ::InitWindowItems
+            0x65 packetDeprecated ::DeclareRecipes
+            0X66 packetDeprecated ::DeclareTags
+            0x1B packetDeprecated ::EntityStatus
+            0x12 packetDeprecated ::DeclareCommands
+            0x38 packetDeprecated ::SetPlayerPositionAndLook
+            0x39 packetDeprecated ::UnlockRecipes
+            0x36 packetDeprecated ::PlayerInfo
+            0x49 packetDeprecated ::UpdateChunkPosition
+            0x22 packetDeprecated ::ChunkData
+            0x25 packetDeprecated ::UpdateLight
+            0x20 packetDeprecated ::WorldBorder
+            0x21 packetDeprecated ::KeepAliveClient
+            0x08 packetDeprecated ::AcknowledgePlayerDigging
+            0x0C packetDeprecated ::BlockChange
+            0x04 packetDeprecated ::SpawnPlayer
+            0x29 packetDeprecated ::UpdateEntityPosition
+            0x2A packetDeprecated ::UpdateEntityPositionRotation
+            0x2B packetDeprecated ::UpdateEntityRotation
+            0x14 packetDeprecated ::InitWindowItems
         }
     }),
     STATUS(1, {
@@ -127,15 +128,15 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
         NetworkFlow.SERVERBOUND -> builder.server.getId(msg.javaClass)
     }
 
-    fun createPacket(networkFlow: NetworkFlow, packetId: Int): PacketBase? = when (networkFlow) {
-        NetworkFlow.CLIENTBOUND -> builder.client.createPacket(packetId)
-        NetworkFlow.SERVERBOUND -> builder.server.createPacket(packetId)
+    fun createPacket(networkFlow: NetworkFlow, packetId: Int, buf: PacketByteBuf): PacketBase? = when (networkFlow) {
+        NetworkFlow.CLIENTBOUND -> builder.client.createPacket(packetId, buf)
+        NetworkFlow.SERVERBOUND -> builder.server.createPacket(packetId, buf)
     }
 
     class Builder {
         class FlowBuilder(val flow: NetworkFlow) {
             val classToId: Object2IntMap<Class<out PacketBase>> = Object2IntOpenHashMap()
-            val idToConstructor: Int2ObjectMap<Supplier<out PacketBase>> = Int2ObjectOpenHashMap()
+            val idToConstructor: Int2ObjectMap<Function<PacketByteBuf, out PacketBase>> = Int2ObjectOpenHashMap()
 
             init {
                 classToId.defaultReturnValue(-1)
@@ -146,10 +147,19 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
             val allPackets: Iterable<Class<out PacketBase>>
                 get() = Iterables.unmodifiableIterable(classToId.keys)
 
-            fun createPacket(packetId: Int): PacketBase? =
-                if (!idToConstructor.containsKey(packetId)) null else idToConstructor[packetId].get()
+            fun createPacket(packetId: Int, buf: PacketByteBuf): PacketBase? =
+                if (!idToConstructor.containsKey(packetId)) null else idToConstructor[packetId].apply(buf)
 
-            inline infix fun <reified P : PacketBase> Int.packet(packetSupplier: Supplier<P>) {
+            @Deprecated("use PacketByteBuf constructor instead")
+            inline infix fun <reified P : PacketBase> Int.packetDeprecated(packetSupplier: Supplier<P>) {
+                packet { buf ->
+                    val packet = packetSupplier.get()
+                    packet.read(buf)
+                    packet
+                }
+            }
+
+            inline infix fun <reified P : PacketBase> Int.packet(packetSupplier: Function<PacketByteBuf, P>) {
                 val id = classToId.put(P::class.java, this)
                 require(id == -1) { "Packet ${P::class.java} is already registered to ID $id" }
                 idToConstructor[this] = packetSupplier
@@ -163,3 +173,5 @@ enum class Protocol(private val id: Int, block: Builder.() -> Unit) {
         inline fun server(block: FlowBuilder.() -> Unit): FlowBuilder = server.apply(block)
     }
 }
+
+typealias PacketFactory = (PacketByteBuf) -> PacketBase

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/clientbound/PingRequest.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/clientbound/PingRequest.kt
@@ -7,12 +7,7 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.handshake.serverbound.PongResponse
 
 class PingRequest(private var time: Long) : Packet {
-
-    constructor() : this(-1)
-
-    override fun read(buf: PacketByteBuf) {
-        time = buf.readLong()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readLong())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeLong(time)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/clientbound/StatusRequest.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/clientbound/StatusRequest.kt
@@ -6,8 +6,9 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.handshake.serverbound.StatusResponse
 
-class StatusRequest : Packet {
-    override fun read(buf: PacketByteBuf) {}
+class StatusRequest() : Packet {
+    constructor(buf: PacketByteBuf) : this()
+
     override fun write(buf: PacketByteBuf) {}
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/PongResponse.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/PongResponse.kt
@@ -7,11 +7,7 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
 class PongResponse(private var time: Long) : Packet {
 
-    constructor() : this(0)
-
-    override fun read(buf: PacketByteBuf) {
-        time = buf.readLong()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readLong())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeLong(time)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/PongResponse.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/PongResponse.kt
@@ -6,7 +6,6 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
 class PongResponse(private var time: Long) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readLong())
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/StatusResponse.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/StatusResponse.kt
@@ -5,16 +5,12 @@ import org.sandboxpowered.silica.vanilla.network.Packet
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
-class StatusResponse(private var responseJson: String?) : Packet {
+class StatusResponse(private var responseJson: String) : Packet {
 
-    constructor() : this(null)
-
-    override fun read(buf: PacketByteBuf) {
-        responseJson = buf.readString()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readString())
 
     override fun write(buf: PacketByteBuf) {
-        buf.writeString(responseJson!!)
+        buf.writeString(responseJson)
     }
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/StatusResponse.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/handshake/serverbound/StatusResponse.kt
@@ -6,7 +6,6 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
 class StatusResponse(private var responseJson: String) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readString())
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/Disconnect.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/Disconnect.kt
@@ -6,7 +6,6 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
 class Disconnect(private var reason: String) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readString())
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/Disconnect.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/Disconnect.kt
@@ -5,16 +5,12 @@ import org.sandboxpowered.silica.vanilla.network.Packet
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
-class Disconnect(private var reason: String?) : Packet {
+class Disconnect(private var reason: String) : Packet {
 
-    constructor() : this(null)
-
-    override fun read(buf: PacketByteBuf) {
-        reason = buf.readString()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readString())
 
     override fun write(buf: PacketByteBuf) {
-        buf.writeString(reason!!)
+        buf.writeString(reason)
     }
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/EncryptionRequest.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/EncryptionRequest.kt
@@ -10,7 +10,6 @@ class EncryptionRequest(
     private var publicKey: ByteArray,
     private var verifyArray: ByteArray
 ) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readString(20), buf.readByteArray(), buf.readByteArray())
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/EncryptionRequest.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/EncryptionRequest.kt
@@ -6,23 +6,17 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
 class EncryptionRequest(
-    private var serverId: String?,
-    private var publicKey: ByteArray?,
-    private var verifyArray: ByteArray?
+    private var serverId: String,
+    private var publicKey: ByteArray,
+    private var verifyArray: ByteArray
 ) : Packet {
 
-    constructor() : this(null, null, null)
-
-    override fun read(buf: PacketByteBuf) {
-        serverId = buf.readString(20)
-        publicKey = buf.readByteArray()
-        verifyArray = buf.readByteArray()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readString(20), buf.readByteArray(), buf.readByteArray())
 
     override fun write(buf: PacketByteBuf) {
-        buf.writeString(serverId!!)
-        buf.writeByteArray(publicKey!!)
-        buf.writeByteArray(verifyArray!!)
+        buf.writeString(serverId)
+        buf.writeByteArray(publicKey)
+        buf.writeByteArray(verifyArray)
     }
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/LoginSuccess.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/LoginSuccess.kt
@@ -7,7 +7,6 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import java.util.*
 
 class LoginSuccess(private var uuid: UUID, private var username: String) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readUUID(), buf.readString(16))
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/LoginSuccess.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/clientbound/LoginSuccess.kt
@@ -6,18 +6,13 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import java.util.*
 
-class LoginSuccess(private var uuid: UUID?, private var username: String?) : Packet {
+class LoginSuccess(private var uuid: UUID, private var username: String) : Packet {
 
-    constructor() : this(null, null)
-
-    override fun read(buf: PacketByteBuf) {
-        uuid = buf.readUUID()
-        username = buf.readString(16)
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readUUID(), buf.readString(16))
 
     override fun write(buf: PacketByteBuf) {
-        buf.writeUUID(uuid!!)
-        buf.writeString(username!!)
+        buf.writeUUID(uuid)
+        buf.writeString(username)
     }
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/EncryptionResponse.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/EncryptionResponse.kt
@@ -8,7 +8,6 @@ import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
 class EncryptionResponse(private var sharedSecret: ByteArray, private var verifyToken: ByteArray) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readByteArray(), buf.readByteArray())
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/EncryptionResponse.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/EncryptionResponse.kt
@@ -7,18 +7,13 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
 
-class EncryptionResponse(private var sharedSecret: ByteArray?, private var verifyToken: ByteArray?) : Packet {
+class EncryptionResponse(private var sharedSecret: ByteArray, private var verifyToken: ByteArray) : Packet {
 
-    constructor() : this(null, null)
-
-    override fun read(buf: PacketByteBuf) {
-        sharedSecret = buf.readByteArray()
-        verifyToken = buf.readByteArray()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readByteArray(), buf.readByteArray())
 
     override fun write(buf: PacketByteBuf) {
-        buf.writeByteArray(sharedSecret!!)
-        buf.writeByteArray(verifyToken!!)
+        buf.writeByteArray(sharedSecret)
+        buf.writeByteArray(verifyToken)
     }
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {
@@ -27,7 +22,7 @@ class EncryptionResponse(private var sharedSecret: ByteArray?, private var verif
 
     @Throws(EncryptionException::class)
     fun getSecretKey(key: Key): SecretKey {
-        val cs = decryptUsingKey(key, sharedSecret!!)
+        val cs = decryptUsingKey(key, sharedSecret)
         return try {
             SecretKeySpec(cs, "AES")
         } catch (var4: Exception) {
@@ -36,7 +31,7 @@ class EncryptionResponse(private var sharedSecret: ByteArray?, private var verif
     }
 
     fun getVerificationToken(key: Key): ByteArray {
-        return decryptUsingKey(key, verifyToken!!)
+        return decryptUsingKey(key, verifyToken)
     }
 
     fun getCipher(i: Int, key: Key): Cipher {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/HandshakeRequest.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/HandshakeRequest.kt
@@ -12,7 +12,6 @@ class HandshakeRequest(
     private var port: UShort,
     private var intention: Int,
 ) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readVarInt(), buf.readString(255), buf.readUShort(), buf.readVarInt())
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/HandshakeRequest.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/HandshakeRequest.kt
@@ -8,23 +8,16 @@ import org.sandboxpowered.silica.vanilla.network.Protocol.Companion.getProtocolF
 
 class HandshakeRequest(
     private var protocolVersion: Int,
-    private var hostName: String?,
+    private var hostName: String,
     private var port: UShort,
     private var intention: Int,
 ) : Packet {
 
-    constructor() : this(0, null, 0u, 0)
-
-    override fun read(buf: PacketByteBuf) {
-        protocolVersion = buf.readVarInt()
-        hostName = buf.readString(255)
-        port = buf.readUShort()
-        intention = buf.readVarInt()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readVarInt(), buf.readString(255), buf.readUShort(), buf.readVarInt())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeVarInt(protocolVersion)
-        buf.writeString(hostName!!)
+        buf.writeString(hostName)
         buf.writeUShort(port)
         buf.writeVarInt(intention)
     }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/LoginStart.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/LoginStart.kt
@@ -6,7 +6,6 @@ import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
 class LoginStart(private var username: String) : Packet {
-
     constructor(buf: PacketByteBuf) : this(buf.readString(16))
 
     override fun write(buf: PacketByteBuf) {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/LoginStart.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/login/serverbound/LoginStart.kt
@@ -5,19 +5,15 @@ import org.sandboxpowered.silica.vanilla.network.Packet
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 
-class LoginStart(private var username: String?) : Packet {
+class LoginStart(private var username: String) : Packet {
 
-    constructor() : this(null)
-
-    override fun read(buf: PacketByteBuf) {
-        username = buf.readString(16)
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readString(16))
 
     override fun write(buf: PacketByteBuf) {
-        buf.writeString(username!!)
+        buf.writeString(username)
     }
 
     override fun handle(packetHandler: PacketHandler, connection: Connection) {
-        connection.handleLoginStart(username!!)
+        connection.handleLoginStart(username)
     }
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/AcknowledgePlayerDigging.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/AcknowledgePlayerDigging.kt
@@ -1,23 +1,21 @@
 package org.sandboxpowered.silica.vanilla.network.play.clientbound
 
+import org.sandboxpowered.silica.util.math.Position
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
-import org.sandboxpowered.silica.util.math.Position
 
 class AcknowledgePlayerDigging(
-    private val pos: Position? = null,
-    private val blockState: Int = 0,
-    private val status: Int = 0,
-    private val success: Boolean = false,
+    private val pos: Position,
+    private val blockState: Int,
+    private val status: Int,
+    private val success: Boolean,
 ) : PacketPlay {
-    override fun read(buf: PacketByteBuf) {
-        TODO("Not yet implemented")
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readPosition(), buf.readVarInt(), buf.readVarInt(), buf.readBoolean())
 
     override fun write(buf: PacketByteBuf) {
-        buf.writePosition(pos!!)
+        buf.writePosition(pos)
         buf.writeVarInt(blockState)
         buf.writeVarInt(status)
         buf.writeBoolean(success)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/BlockChange.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/BlockChange.kt
@@ -1,18 +1,16 @@
 package org.sandboxpowered.silica.vanilla.network.play.clientbound
 
+import org.sandboxpowered.silica.util.math.Position
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
-import org.sandboxpowered.silica.util.math.Position
 
-class BlockChange(var location: Position? = null, var blockId: Int = -1) : PacketPlay {
-    override fun read(buf: PacketByteBuf) {
-        TODO("Not yet implemented")
-    }
+class BlockChange(var location: Position, var blockId: Int) : PacketPlay {
+    constructor(buf: PacketByteBuf) : this(buf.readPosition(), buf.readVarInt())
 
     override fun write(buf: PacketByteBuf) {
-        buf.writePosition(location!!)
+        buf.writePosition(location)
         buf.writeVarInt(blockId)
     }
 

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/ChunkData.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/ChunkData.kt
@@ -9,7 +9,8 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 import org.sandboxpowered.silica.vanilla.network.play.clientbound.world.VanillaChunkSection
 import org.sandboxpowered.silica.vanilla.network.util.BitPackedLongArray
-import org.sandboxpowered.silica.world.state.block.BlockState
+import org.sandboxpowered.silica.world.ChunkSectionPos
+import org.sandboxpowered.silica.world.VanillaWorldAdapter
 import org.sandboxpowered.silica.world.util.BlocTree
 import java.util.*
 
@@ -21,15 +22,15 @@ class ChunkData() : PacketPlay {
     private var buffer: ByteArray = byteArrayOf()
     private var biomes: IntArray = intArrayOf()
 
-    constructor(cX: Int, cZ: Int, blocTree: BlocTree, stateToId: (BlockState) -> Int) : this() {
+    constructor(cX: Int, cZ: Int, world: BlocTree, adapter: VanillaWorldAdapter) : this() {
         this.cX = cX
         this.cZ = cZ
         biomes = IntArray(1024)
         for (i in 0..15) {
-            sections[i] = VanillaChunkSection(blocTree, cX * 16, i * 16, cZ * 16, stateToId)
+            sections[i] = adapter.getVanillaChunkSection(ChunkSectionPos(cX, i, cZ))
         }
         buffer = ByteArray(calculateSize(cX, cZ))
-        bitMask = extractData(PacketByteBuf(writeBuffer), cX, cZ, blocTree).toLongArray()
+        bitMask = extractData(PacketByteBuf(writeBuffer), cX, cZ, world).toLongArray()
     }
 
     private fun extractData(packetByteBuf: PacketByteBuf, cX: Int, cZ: Int, blocTree: BlocTree): BitSet {

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/DeclareTags.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/DeclareTags.kt
@@ -1,12 +1,12 @@
 package org.sandboxpowered.silica.vanilla.network.play.clientbound
 
+import org.sandboxpowered.silica.util.Hardcoding
+import org.sandboxpowered.silica.util.Identifier
+import org.sandboxpowered.silica.util.Identifier.Companion.of
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
-import org.sandboxpowered.silica.util.Hardcoding
-import org.sandboxpowered.silica.util.Identifier
-import org.sandboxpowered.silica.util.Identifier.Companion.of
 
 class DeclareTags : PacketPlay {
     override fun read(buf: PacketByteBuf) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/HeldItemChangeClientbound.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/HeldItemChangeClientbound.kt
@@ -5,11 +5,8 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
-class HeldItemChangeClientbound(private var slot: Byte = 0) : PacketPlay {
-
-    override fun read(buf: PacketByteBuf) {
-        slot = buf.readByte()
-    }
+class HeldItemChangeClientbound(private var slot: Byte) : PacketPlay {
+    constructor(buf: PacketByteBuf) : this(buf.readByte())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeByte(slot)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/InitWindowItems.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/InitWindowItems.kt
@@ -10,14 +10,12 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
 class InitWindowItems(
-    var window: UByte = 0u,
-    var state: Int = -1,
-    var inventory: PlayerInventory? = null,
-    var protocolMapping: VanillaProtocolMapping? = null
+    var window: UByte,
+    var state: Int,
+    var inventory: PlayerInventory?,
+    var protocolMapping: VanillaProtocolMapping?
 ) : PacketPlay {
-    override fun read(buf: PacketByteBuf) {
-        TODO("Not yet implemented")
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readUByte(), buf.readVarInt(), null, null)
 
     override fun write(buf: PacketByteBuf) {
         val inventory = this.inventory!!

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/JoinGame.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/JoinGame.kt
@@ -1,40 +1,48 @@
 package org.sandboxpowered.silica.vanilla.network.play.clientbound
 
 import org.sandboxpowered.silica.nbt.NBTCompound
+import org.sandboxpowered.silica.util.Identifier
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
-import org.sandboxpowered.silica.util.Identifier
 
 class JoinGame(
-    private var playerId: Int = 0, private var hardcore: Boolean = false, private var gamemode: Short = 0,
-    private var previousGamemode: Short = 0, private var worldCount: Int = 0,
-    private var worldNames: Array<Identifier> = emptyArray(), private var dimCodec: NBTCompound? = null,
-    private var dim: NBTCompound? = null, private var world: Identifier? = null, private var seed: Long = 0,
-    private var maxPlayers: Int = 0, private var viewDistance: Int = 0,
-    private var reducedDebug: Boolean = false, private var respawnScreen: Boolean = false,
-    private var debug: Boolean = false, private var flat: Boolean = false,
+    private var playerId: Int,
+    private var hardcore: Boolean,
+    private var gamemode: Byte,
+    private var previousGamemode: Byte,
+    private var worldCount: Int,
+    private var worldNames: Array<Identifier> = emptyArray(),
+    private var dimCodec: NBTCompound?,
+    private var dim: NBTCompound?,
+    private var world: Identifier,
+    private var seed: Long,
+    private var maxPlayers: Int,
+    private var viewDistance: Int,
+    private var reducedDebug: Boolean,
+    private var respawnScreen: Boolean,
+    private var debug: Boolean,
+    private var flat: Boolean,
 ) : PacketPlay {
-
-    override fun read(buf: PacketByteBuf) {
-        playerId = buf.readInt()
-        hardcore = buf.readBoolean()
-        gamemode = buf.readByte().toShort()
-        previousGamemode = buf.readByte().toShort()
-        worldCount = buf.readVarInt()
-        worldNames = buf.readIdentityArray()
-        dimCodec = buf.readNBT()
-        dim = buf.readNBT()
-        world = buf.readIdentity()
-        seed = buf.readLong()
-        maxPlayers = buf.readVarInt()
-        viewDistance = buf.readVarInt()
-        reducedDebug = buf.readBoolean()
-        respawnScreen = buf.readBoolean()
-        debug = buf.readBoolean()
-        flat = buf.readBoolean()
-    }
+    constructor(buf: PacketByteBuf) : this(
+        buf.readInt(),
+        buf.readBoolean(),
+        buf.readByte(),
+        buf.readByte(),
+        buf.readVarInt(),
+        buf.readIdentityArray(),
+        buf.readNBT(),
+        buf.readNBT(),
+        buf.readIdentity(),
+        buf.readLong(),
+        buf.readVarInt(),
+        buf.readVarInt(),
+        buf.readBoolean(),
+        buf.readBoolean(),
+        buf.readBoolean(),
+        buf.readBoolean()
+    )
 
     override fun write(buf: PacketByteBuf) {
         buf.writeInt(playerId)
@@ -45,7 +53,7 @@ class JoinGame(
         buf.writeIdentityArray(worldNames)
         buf.writeNBT(dimCodec)
         buf.writeNBT(dim)
-        buf.writeIdentity(world!!)
+        buf.writeIdentity(world)
         buf.writeLong(seed)
         buf.writeVarInt(maxPlayers)
         buf.writeVarInt(viewDistance)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/KeepAliveClient.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/clientbound/KeepAliveClient.kt
@@ -5,11 +5,8 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
-class KeepAliveClient(private var id: Long = 0) : PacketPlay {
-
-    override fun read(buf: PacketByteBuf) {
-        id = buf.readLong()
-    }
+class KeepAliveClient(private var id: Long) : PacketPlay {
+    constructor(buf: PacketByteBuf) : this(buf.readLong())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeLong(id)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/ClientPluginChannel.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/ClientPluginChannel.kt
@@ -1,18 +1,13 @@
 package org.sandboxpowered.silica.vanilla.network.play.serverbound
 
+import org.sandboxpowered.silica.util.Identifier
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
-import org.sandboxpowered.silica.util.Identifier
 
-class ClientPluginChannel(
-    private var channel: Identifier? = null, private var data: ByteArray = byteArrayOf(),
-) : PacketPlay {
-    override fun read(buf: PacketByteBuf) {
-        channel = buf.readIdentity()
-        data = buf.readByteArray()
-    }
+class ClientPluginChannel(private var channel: Identifier, private var data: ByteArray) : PacketPlay {
+    constructor(buf: PacketByteBuf) : this(buf.readIdentity(), buf.readByteArray())
 
     override fun write(buf: PacketByteBuf) {}
     override fun handle(packetHandler: PacketHandler, context: PlayContext) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/ClientSettings.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/ClientSettings.kt
@@ -6,20 +6,23 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
 class ClientSettings(
-    private var language: String? = null, private var renderDistance: Byte = 0,
-    private var chatMode: Int = 0, private var enableColour: Boolean = false,
-    private var displayedSkin: UByte = 0u, private var hand: Int = 0,
-    private var textFiltering: Boolean = false,
+    private var language: String,
+    private var renderDistance: Byte,
+    private var chatMode: Int,
+    private var enableColour: Boolean,
+    private var displayedSkin: UByte,
+    private var hand: Int,
+    private var textFiltering: Boolean,
 ) : PacketPlay {
-    override fun read(buf: PacketByteBuf) {
-        language = buf.readString(16)
-        renderDistance = buf.readByte()
-        chatMode = buf.readVarInt()
-        enableColour = buf.readBoolean()
-        displayedSkin = buf.readUByte()
-        hand = buf.readVarInt()
-        textFiltering = buf.readBoolean()
-    }
+    constructor(buf: PacketByteBuf) : this(
+        buf.readString(16),
+        buf.readByte(),
+        buf.readVarInt(),
+        buf.readBoolean(),
+        buf.readUByte(),
+        buf.readVarInt(),
+        buf.readBoolean()
+    )
 
     override fun write(buf: PacketByteBuf) {}
     override fun handle(packetHandler: PacketHandler, context: PlayContext) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/KeepAliveServer.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/KeepAliveServer.kt
@@ -6,12 +6,7 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
 class KeepAliveServer(private var id: Long) : PacketPlay {
-
-    constructor() : this(0)
-
-    override fun read(buf: PacketByteBuf) {
-        id = buf.readLong()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readLong())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeLong(id)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerBlockPlacement.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerBlockPlacement.kt
@@ -1,12 +1,12 @@
 package org.sandboxpowered.silica.vanilla.network.play.serverbound
 
 import org.sandboxpowered.silica.content.block.Blocks
+import org.sandboxpowered.silica.util.content.Direction
+import org.sandboxpowered.silica.util.math.Position
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
-import org.sandboxpowered.silica.util.content.Direction
-import org.sandboxpowered.silica.util.math.Position
 
 class PlayerBlockPlacement(
     var hand: Int = -1,

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerDigging.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerDigging.kt
@@ -1,41 +1,34 @@
 package org.sandboxpowered.silica.vanilla.network.play.serverbound
 
 import org.sandboxpowered.silica.content.block.Blocks
+import org.sandboxpowered.silica.util.math.Position
 import org.sandboxpowered.silica.vanilla.network.PacketByteBuf
 import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 import org.sandboxpowered.silica.vanilla.network.play.clientbound.AcknowledgePlayerDigging
-import org.sandboxpowered.silica.util.math.Position
 
-class PlayerDigging(private var status: Int, private var location: Position?, private var face: Byte) : PacketPlay {
-
-    constructor() : this(-1, null, -1)
-
-    override fun read(buf: PacketByteBuf) {
-        status = buf.readVarInt()
-        location = buf.readPosition()
-        face = buf.readByte()
-    }
+class PlayerDigging(private var status: Int, private var location: Position, private var face: Byte) : PacketPlay {
+    constructor(buf: PacketByteBuf) : this(buf.readVarInt(), buf.readPosition(), buf.readByte())
 
     override fun write(buf: PacketByteBuf) {
-
+        buf.writeVarInt(status)
+        buf.writePosition(location)
+        buf.writeByte(face)
     }
 
     override fun handle(packetHandler: PacketHandler, context: PlayContext) {
         println("Player Digging: $status $location $face")
-        location?.let { pos ->
-            context.mutateWorld {
-                it.setBlockState(pos, Blocks.AIR.get().defaultState)
-                packetHandler.sendPacket(
-                    AcknowledgePlayerDigging(
-                        pos,
-                        context.server.stateRemapper.toVanillaId(it.getBlockState(pos)),
-                        status,
-                        true
-                    )
+        context.mutateWorld {
+            it.setBlockState(location, Blocks.AIR.get().defaultState)
+            packetHandler.sendPacket(
+                AcknowledgePlayerDigging(
+                    location,
+                    context.server.stateRemapper.toVanillaId(it.getBlockState(location)),
+                    status,
+                    true
                 )
-            }
+            )
         }
     }
 }

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerMovement.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerMovement.kt
@@ -5,11 +5,9 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
-class PlayerMovement(private var onGround: Boolean = false) : PacketPlay {
+class PlayerMovement(private var onGround: Boolean) : PacketPlay {
 
-    override fun read(buf: PacketByteBuf) {
-        onGround = buf.readBoolean()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readBoolean())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeBoolean(onGround)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerPosition.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerPosition.kt
@@ -6,16 +6,12 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
 class PlayerPosition(
-    private var x: Double = 0.0, private var y: Double = 0.0, private var z: Double = 0.0,
-    private var onGround: Boolean = false,
+    private var x: Double,
+    private var y: Double,
+    private var z: Double,
+    private var onGround: Boolean,
 ) : PacketPlay {
-
-    override fun read(buf: PacketByteBuf) {
-        x = buf.readDouble()
-        y = buf.readDouble()
-        z = buf.readDouble()
-        onGround = buf.readBoolean()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readDouble(), buf.readDouble(), buf.readDouble(), buf.readBoolean())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeDouble(x)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerPositionAndRotation.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerPositionAndRotation.kt
@@ -6,19 +6,21 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
 class PlayerPositionAndRotation(
-    private var x: Double = 0.0, private var y: Double = 0.0, private var z: Double = 0.0,
-    private var yaw: Float = 0f, private var pitch: Float = 0f,
-    private var onGround: Boolean = false,
+    private var x: Double,
+    private var y: Double,
+    private var z: Double,
+    private var yaw: Float,
+    private var pitch: Float,
+    private var onGround: Boolean,
 ) : PacketPlay {
-
-    override fun read(buf: PacketByteBuf) {
-        x = buf.readDouble()
-        y = buf.readDouble()
-        z = buf.readDouble()
-        yaw = buf.readFloat()
-        pitch = buf.readFloat()
-        onGround = buf.readBoolean()
-    }
+    constructor(buf: PacketByteBuf) : this(
+        buf.readDouble(),
+        buf.readDouble(),
+        buf.readDouble(),
+        buf.readFloat(),
+        buf.readFloat(),
+        buf.readBoolean()
+    )
 
     override fun write(buf: PacketByteBuf) {
         buf.writeDouble(x)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerRotation.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/PlayerRotation.kt
@@ -6,15 +6,11 @@ import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
 class PlayerRotation(
-    private var yaw: Float = 0f,
-    private var pitch: Float = 0f,
-    private var onGround: Boolean = false,
+    private var yaw: Float,
+    private var pitch: Float,
+    private var onGround: Boolean,
 ) : PacketPlay {
-    override fun read(buf: PacketByteBuf) {
-        yaw = buf.readFloat()
-        pitch = buf.readFloat()
-        onGround = buf.readBoolean()
-    }
+    constructor(buf: PacketByteBuf) : this(buf.readFloat(), buf.readFloat(), buf.readBoolean())
 
     override fun write(buf: PacketByteBuf) {
         buf.writeFloat(yaw)

--- a/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/TeleportConfirmation.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/vanilla/network/play/serverbound/TeleportConfirmation.kt
@@ -5,11 +5,8 @@ import org.sandboxpowered.silica.vanilla.network.PacketHandler
 import org.sandboxpowered.silica.vanilla.network.PacketPlay
 import org.sandboxpowered.silica.vanilla.network.PlayContext
 
-class TeleportConfirmation(private var tpId: Int = 0) : PacketPlay {
-
-    override fun read(buf: PacketByteBuf) {
-        tpId = buf.readVarInt()
-    }
+class TeleportConfirmation(private var tpId: Int) : PacketPlay {
+    constructor(buf: PacketByteBuf) : this(buf.readVarInt())
 
     override fun write(buf: PacketByteBuf) {}
     override fun handle(packetHandler: PacketHandler, context: PlayContext) {}

--- a/common/src/main/kotlin/org/sandboxpowered/silica/world/VanillaWorldAdapter.kt
+++ b/common/src/main/kotlin/org/sandboxpowered/silica/world/VanillaWorldAdapter.kt
@@ -1,0 +1,23 @@
+package org.sandboxpowered.silica.world
+
+import org.sandboxpowered.silica.util.math.Position
+import org.sandboxpowered.silica.vanilla.network.play.clientbound.world.VanillaChunkSection
+import org.sandboxpowered.silica.world.state.block.BlockState
+
+class VanillaWorldAdapter(val world: SilicaWorld) {
+    private val vanillaChunkSectionMap = HashMap<ChunkSectionPos, VanillaChunkSection>()
+
+    fun getVanillaChunkSection(pos: ChunkSectionPos): VanillaChunkSection {
+        return vanillaChunkSectionMap.computeIfAbsent(pos) {
+            VanillaChunkSection(world.getTerrain(), it.x * 16, it.y * 16, it.z * 16) { state ->
+                world.server.stateRemapper.toVanillaId(state)
+            }
+        }
+    }
+
+    fun propagateUpdate(pos: Position, oldState: BlockState, newState: BlockState) {
+        TODO("Not yet implemented")
+    }
+}
+
+data class ChunkSectionPos(val x: Int, val y: Int, val z: Int)


### PR DESCRIPTION
Some packets have been converted however a lot of packets require a much further look into whether their structure/creation is reasonable or should be improved with additions elsewhere in the code base.

These are mostly the world packets as well as some of the general data sync such as tags and recipes.